### PR TITLE
Fix: correctly handle filenames containing $

### DIFF
--- a/total_playtime.lua
+++ b/total_playtime.lua
@@ -58,6 +58,7 @@ function total_time()
 			until n == 0
 			
 			f = string.gsub(f, "\"", "\\\"")
+			f = string.gsub(f, "%$", "\\$")
 			
 			if save_probed and probed_file[f] then
 				fprobe = probed_file[f]


### PR DESCRIPTION
Hey, noticed the script broke for a filename with a `$` character in it. Properly escaping those characters fixes it :)